### PR TITLE
Feature: Networking setup

### DIFF
--- a/DropboxBrowser/APIClient/.gitignore
+++ b/DropboxBrowser/APIClient/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/DropboxBrowser/APIClient/Package.swift
+++ b/DropboxBrowser/APIClient/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "APIClient",
+    platforms: [
+            .iOS(.v15)
+        ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/DropboxBrowser/APIClient/Package.swift
+++ b/DropboxBrowser/APIClient/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 5.8
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "APIClient",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "APIClient",
+            targets: ["APIClient"])
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "APIClient",
+            dependencies: []),
+        .testTarget(
+            name: "APIClientTests",
+            dependencies: ["APIClient"])
+    ]
+)

--- a/DropboxBrowser/APIClient/README.md
+++ b/DropboxBrowser/APIClient/README.md
@@ -1,0 +1,3 @@
+# APIClient
+
+A description of this package.

--- a/DropboxBrowser/APIClient/Sources/APIClient/APIClient.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/APIClient.swift
@@ -1,6 +1,0 @@
-public struct APIClient {
-    public private(set) var text = "Hello, World!"
-
-    public init() {
-    }
-}

--- a/DropboxBrowser/APIClient/Sources/APIClient/APIClient.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/APIClient.swift
@@ -1,0 +1,6 @@
+public struct APIClient {
+    public private(set) var text = "Hello, World!"
+
+    public init() {
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/APIClient/URLSessionClient+Request.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/APIClient/URLSessionClient+Request.swift
@@ -1,0 +1,20 @@
+//
+// URLSessionClient+Request.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Part of the `URLSessionClient` responsible for sending requests.
+extension URLSessionClient {
+
+    func send<T>(_ request: T,
+                 requestBuilder: RequestBuilder) async throws -> T.Response where T: APIRequest {
+        let urlRequest = try requestBuilder.makeRequest(request, baseURL: baseURL)
+        let (data, response) = try await session.data(for: urlRequest)
+        return try process(responseData: data, response: response, request: request)
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/APIClient/URLSessionClient+Response.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/APIClient/URLSessionClient+Response.swift
@@ -1,0 +1,48 @@
+//
+// URLSessionClient+Response.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Part of the `URLSessionClient` responsible for processing response `Data`.
+extension URLSessionClient {
+
+    func process<T: APIRequest>(responseData data: Data,
+                                response: URLResponse,
+                                request: T) throws -> T.Response {
+
+        let headers = (response as? HTTPURLResponse)?.allHeaderFields ?? [:]
+        let decoder = ResponseDecoderFactory.makeDecoder(for: headers)
+
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+        switch statusCode {
+        case 200...299:
+            do {
+                return try decoder.decode(T.Response.self, from: data)
+            } catch {
+                print(error)
+                throw NetworkingError.decoding(rawData: data, error: error)
+            }
+        case 400:
+            let payload = try decoder.decode(HTTPErrorPayload.self, from: data)
+            throw HTTPError.badRequest(payload)
+        case 401:
+            throw HTTPError.unauthorised
+        case 403:
+            let payload = try decoder.decode(HTTPErrorPayload.self, from: data)
+            throw HTTPError.forbidden(payload)
+        case 429:
+            let payload = try decoder.decode(HTTPErrorPayload.self, from: data)
+            throw HTTPError.tooManyRequests(payload)
+        case 500:
+            let payload = try decoder.decode(HTTPErrorPayload.self, from: data)
+            throw HTTPError.internalServer(payload)
+        default:
+            throw NetworkingError.unknown
+        }
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/APIClient/URLSessionClient.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/APIClient/URLSessionClient.swift
@@ -1,0 +1,70 @@
+//
+// URLSessionClient.swift
+// APIClient
+//
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// `URLSession` powered implementaion of `APIClient` protocol.
+public class URLSessionClient: APIClient {
+
+    /// URLSession isntance to perform network request.
+    let session: URLSession
+
+    /// Base URL for session to build `APIRequest` resource URL.
+    let baseURL: URL
+
+    /// Instance of `URLRequestBuilder` to transform `APIRequest` protocol
+    /// implementation into instance of `URLRequest`.
+    private let requestBuilder: URLRequestBuilder
+
+    /// Instance of `UploadRequestBuilder` to transform `APIRequest` protocol
+    /// and file `URL` to instance of `URLRequest`.
+    private let uploadBuilder: UploadRequestBuilder
+
+    public init(session: URLSession = URLSession.shared,
+                requestBuilder: URLRequestBuilder,
+                uploadBuilder: UploadRequestBuilder,
+                baseURL: URL) {
+        self.session = session
+        self.baseURL = baseURL
+        self.requestBuilder = requestBuilder
+        self.uploadBuilder = uploadBuilder
+    }
+
+    // MARK: - Send Request Interface
+
+    public func send<T>(_ request: T) async throws -> T.Response where T: APIRequest {
+        return try await send(request, requestBuilder: requestBuilder)
+    }
+
+    // MARK: - File Upload Interface
+
+    public func upload<T>(_ request: T, fileURL: URL) async throws -> T.Response where T: APIRequest {
+        return try await send(request, requestBuilder: uploadBuilder)
+    }
+
+    // MARK: - File Download Interface
+
+    public func download<T>(_ request: T) async throws -> URL where T: APIRequest {
+        let urlRequest = try requestBuilder.makeRequest(request, baseURL: baseURL)
+        let (url, _) = try await session.download(for: urlRequest, delegate: nil)
+
+        guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            throw NetworkingError.responseProcessing
+        }
+
+        let fileURL = documentsDirectory.appendingPathComponent(url.lastPathComponent)
+        do {
+            if FileManager.default.fileExists(atPath: fileURL.path) {
+                try FileManager.default.removeItem(at: fileURL)
+            }
+            try FileManager.default.moveItem(at: url, to: fileURL)
+            return fileURL
+        } catch {
+            throw NetworkingError.responseProcessing
+        }
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Authorization/AuthorizationStrategy.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Authorization/AuthorizationStrategy.swift
@@ -1,0 +1,12 @@
+//
+//  AuthorizationStrategy.swift
+//  
+//
+//  Created by Ostap Holub on 23.02.2023.
+//
+
+import Foundation
+
+public protocol AuthorizationStrategy {
+    var value: String? { get }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Authorization/AuthorizationStrategyProvider.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Authorization/AuthorizationStrategyProvider.swift
@@ -1,0 +1,20 @@
+//
+//  AuthorizationStrategyProvider.swift
+//  
+//
+//  Created by Ostap Holub on 23.02.2023.
+//
+
+import Foundation
+
+public protocol AuthorizationStrategyProvider {
+
+    func makeStrategy(_ type: Authorization) -> AuthorizationStrategy
+}
+
+final class AlwaysNoAuthorizationProvider: AuthorizationStrategyProvider {
+
+    func makeStrategy(_ type: Authorization) -> AuthorizationStrategy {
+        NoAuthorizationStrategy()
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Authorization/NoAuthorizationStrategy.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Authorization/NoAuthorizationStrategy.swift
@@ -1,0 +1,17 @@
+//
+//  NoAuthorizationStrategy.swift
+//  
+//
+//  Created by Ostap Holub on 23.02.2023.
+//
+
+import Foundation
+
+public final class NoAuthorizationStrategy: AuthorizationStrategy {
+
+    public init() {}
+
+    public var value: String? {
+        nil
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Logs/RequestLoggingURLProtocol.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Logs/RequestLoggingURLProtocol.swift
@@ -1,0 +1,27 @@
+//
+// RequestLoggingURLProtocol.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Defines `URLProtocol` responsible for logging all API requests
+public class RequestLoggingURLProtocol: URLProtocol {
+
+    public override class func canInit(with request: URLRequest) -> Bool {
+        let logMessage =
+                        """
+                        --- Log Start ---
+                        Loading of request started.
+                        URL: \(request.url?.absoluteString ?? "No URL found")
+                        HTTP Method: \(request.httpMethod ?? "No Method found")
+                        HTTP Body: \(request.httpBody == nil ? "No Body found" : String(data: request.httpBody!, encoding: .utf8)!)
+                        --- Log End ---
+                        """
+        print(logMessage)
+        return false
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Mocks/MockingURLProtocol.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Mocks/MockingURLProtocol.swift
@@ -1,0 +1,58 @@
+//
+// MockingURLProtocol.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Custom implementation fo `URLProtocol`. Provides mocked responses with `Data` or `Error`
+/// using `MocksRegistry` as a source.
+public class MockingURLProtocol: URLProtocol {
+
+    public override class func canInit(with request: URLRequest) -> Bool {
+        MocksRegistry.contains(request)
+    }
+
+    public override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    public override func startLoading() {
+        guard let url = request.url,
+              let response = MocksRegistry.response(for: request) else {
+                  fatalError(
+                    "No mock response for \(request.url!). This should never happen. Check " +
+                    "the implementation of `canInit(with request: URLRequest) -> Bool`"
+                  )
+              }
+
+        // Simulate response on a background thread.
+        DispatchQueue.global(qos: .default).async {
+            switch response {
+            case let .success(data):
+
+                // Simulate receiving an URLResponse. We need to do this
+                // to let the client know the expected status code.
+                let urlResponse = HTTPURLResponse(url: url, statusCode: 200,
+                                                  httpVersion: nil,
+                                                  headerFields: [:])
+
+                self.client?.urlProtocol(self, didReceive: urlResponse!, cacheStoragePolicy: .notAllowed)
+
+                // Simulate received data.
+                self.client?.urlProtocol(self, didLoad: data)
+
+                // Finish loading (required).
+                self.client?.urlProtocolDidFinishLoading(self)
+            case let .failure(error):
+                // Simulate error.
+                self.client?.urlProtocol(self, didFailWithError: error)
+            }
+        }
+    }
+
+    public override func stopLoading() { }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Mocks/MocksRegistry.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Mocks/MocksRegistry.swift
@@ -1,0 +1,78 @@
+//
+// MocksRegistry.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Registry provides a place to hold mocked response data for
+/// HTTP requests based on `APIRequest` implmentation.
+public enum MocksRegistry {
+
+    /// Registration of mock response data is happening using `add(mockData: Data, for request: APIRequest)`
+    /// or the same method registering result error. Registration key is the request `URL`.
+    static var registry: [URLRequest: Result<Data, Error>] = [:]
+
+    /// Adds mock data entry to the `registry`.
+    /// - Parameters:
+    ///     - mockData: Mocked piece of data as a response to request.
+    ///     - request: Implementation of `APIRequest` protocol. Used for registry key generation.
+    public static func add<T: APIRequest>(mockData: Data, for request: T) {
+        let requestBuilder = URLRequestBuilder(authorizationProvider: AlwaysNoAuthorizationProvider())
+
+        do {
+            let urlRequest = try requestBuilder.makeRequest(request, baseURL: URL(fileURLWithPath: ""))
+            registry[urlRequest] = .success(mockData)
+        } catch {
+            print("Failed registering \(request) due to error: \(error)")
+        }
+    }
+
+    /// Adds mock data entry to the `registry`.
+    /// - Parameters:
+    ///    - mockError: Mocked piece of error as a response to request.
+    ///    - request: Implementation of `APIRequest` protocol. Used for registry key generation.
+    public static func add<T: APIRequest>(mockError: Error, for request: T) {
+        let requestBuilder = URLRequestBuilder(authorizationProvider: AlwaysNoAuthorizationProvider())
+
+        do {
+            let urlRequest = try requestBuilder.makeRequest(request, baseURL: URL(fileURLWithPath: ""))
+            registry[urlRequest] = .failure(mockError)
+        } catch {
+            print("Failed registering \(request) due to error: \(error)")
+        }
+    }
+
+    /// Removes entry data for request.
+    /// - Parameters:
+    ///    - request: Implementation of `APIRequest` protocol. Used for registry key generation.
+    public static func remove<T: APIRequest>(request: T) {
+        let requestBuilder = URLRequestBuilder(authorizationProvider: AlwaysNoAuthorizationProvider())
+
+        do {
+            let urlRequest = try requestBuilder.makeRequest(request, baseURL: URL(fileURLWithPath: ""))
+            registry.removeValue(forKey: urlRequest)
+        } catch {
+            print("Failed registering \(request) due to error: \(error)")
+        }
+    }
+
+    /// Determines wether registry contains specific instance of `URLRequest`.
+    /// - Parameter request: Instance of `URLRequest` to look for.
+    /// - Returns: `True` if registry contains such request, `false` otherwise.
+    public static func contains(_ request: URLRequest) -> Bool {
+        MocksRegistry.registry.contains(where: { $0.key.url == request.url && $0.key.httpMethod == request.httpMethod })
+    }
+
+    /// Looks for the response data for specific instance of `URLRequest`.
+    /// - Parameter request: Instance of `URLRequest` to look for.
+    /// - Returns: Instance of `Result` with registered `Data` or `Error`.
+    public static func response(for request: URLRequest) -> Result<Data, Error>? {
+        registry.first(where: { $0.key.url == request.url
+            && $0.key.httpMethod == request.httpMethod
+        })?.value
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Model/HTTPParameter.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Model/HTTPParameter.swift
@@ -1,0 +1,57 @@
+//
+//  HTTPParameter.swift
+//  APIClient
+//
+//  Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Internal model enum used as auxiliary type for encoding/decoding process for
+/// `APIRequest` and it's `APIRequest.Response`.
+/// Used for `URLEncoding` startegy like for `GET` requests.
+enum HTTPParameter: Decodable {
+    case string(String)
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+    case array([String])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+        } else if let int = try? container.decode(Int.self) {
+            self = .int(int)
+        } else if let double = try? container.decode(Double.self) {
+            self = .double(double)
+        } else if let strings = try? container.decode(Array<String>.self) {
+            self = .array(strings)
+        } else {
+            throw NetworkingError.encoding
+        }
+    }
+}
+
+extension HTTPParameter {
+
+    var url: URL? {
+        switch self {
+        case .string(let value):
+            return URL(string: value)
+        default:
+            return nil
+        }
+    }
+
+    var string: String? {
+        switch self {
+        case .string(let value):
+            return value
+        default:
+            return nil
+        }
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Model/SDKHeaderKey.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Model/SDKHeaderKey.swift
@@ -1,0 +1,20 @@
+//
+// SDKHeader.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Describes key for custom defined SDK headers.
+enum SDKHeaderKey: String {
+
+    case sdkName = "User-Agent"
+    case sdkVersion = "x-nylas-sdk-verion"
+    case deviceIdiom = "x-nylas-device-idiom"
+    case systemVersion = "x-system-version"
+    case apiVersion = "Nylas-API-Version"
+    case contentType = "Content-Type"
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/RequestBuilder/Builder/RequestBuilder.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/RequestBuilder/Builder/RequestBuilder.swift
@@ -1,0 +1,14 @@
+//
+// RequestBuilder.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+public protocol RequestBuilder {
+
+    func makeRequest<T: APIRequest>(_ apiRequest: T, baseURL: URL) throws -> URLRequest
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/RequestBuilder/Builder/URLRequestBuilder.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/RequestBuilder/Builder/URLRequestBuilder.swift
@@ -1,0 +1,54 @@
+//
+//  URLRequestBuilder.swift
+//  APIClient
+//
+//  Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Builds an instance of `URLRequest`
+public final class URLRequestBuilder: RequestBuilder {
+
+    private let authorizationProvider: AuthorizationStrategyProvider
+
+    public init(authorizationProvider: AuthorizationStrategyProvider) {
+        self.authorizationProvider = authorizationProvider
+    }
+
+    // MARK: - Interface
+    public func makeRequest<T>(_ apiRequest: T, baseURL: URL) throws -> URLRequest where T: APIRequest {
+        guard let resourceURL = URL(string: apiRequest.resourceName, relativeTo: baseURL) else {
+            throw NetworkingError.invalidResource
+        }
+
+        let encoder: ParametersEncoder = ParametersEncodingFactory.makeEncoder(for: apiRequest)
+        var request: URLRequest = try encoder.encode(apiRequest, baseURL: resourceURL)
+        putHeaders(into: &request, from: apiRequest)
+
+        request.httpMethod = apiRequest.method.rawValue
+        return request
+    }
+}
+
+// MARK: - Private processing
+
+private extension URLRequestBuilder {
+
+    /// Adds content of `additionalHeaders` from `APIRequest` instance into `URLRequest`.
+    func putHeaders<T: APIRequest>(into request: inout URLRequest, from apiRequest: T) {
+
+        if apiRequest.requiresAuth {
+            let strategy = authorizationProvider.makeStrategy(apiRequest.authorization)
+            if let authorization = strategy.value {
+                request.addValue(authorization, forHTTPHeaderField: "Authorization")
+            }
+        }
+
+        if let additionalHeaders = apiRequest.additionalHeaders {
+            for (headerField, value) in additionalHeaders {
+                request.addValue(value, forHTTPHeaderField: headerField)
+            }
+        }
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/RequestBuilder/Builder/UploadRequestBuilder.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/RequestBuilder/Builder/UploadRequestBuilder.swift
@@ -1,0 +1,90 @@
+//
+// UploadRequestBuilder.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+// swiftlint:disable all
+import Foundation
+
+public final class UploadRequestBuilder: RequestBuilder {
+
+    private let authorizationProvider: AuthorizationStrategyProvider
+
+    public init(authorizationProvider: AuthorizationStrategyProvider) {
+        self.authorizationProvider = authorizationProvider
+    }
+
+    // MARK: - Interface
+    public func makeRequest<T>(_ apiRequest: T, baseURL: URL) throws -> URLRequest where T: APIRequest {
+        guard let resourceURL = URL(string: apiRequest.resourceName, relativeTo: baseURL) else {
+            throw NetworkingError.invalidResource
+        }
+
+        guard let components = URLComponents(url: resourceURL, resolvingAgainstBaseURL: true) else {
+            throw URLParametersEncoderError.baseURLParsingFailed
+        }
+
+        guard let url = components.url else {
+            throw URLParametersEncoderError.urlAssemblingFailed
+        }
+
+        var request =  URLRequest(url: url)
+        let parametersData = try JSONEncoder().encode(apiRequest)
+        let parameters = try JSONDecoder().decode([String: HTTPParameter].self, from: parametersData)
+
+        guard let fileURL = parameters[FileUpload.Key.fileURL.rawValue]?.url,
+                let filename = parameters[FileUpload.Key.filename.rawValue]?.string,
+                let boundary = parameters[FileUpload.Key.boundary.rawValue]?.string else {
+            throw URLParametersEncoderError.urlAssemblingFailed
+        }
+
+        request.httpBody = createHttpBody(binaryData: try Data(contentsOf: fileURL),
+                                          mimeType: fileURL.mimeType,
+                                          filename: filename,
+                                          boundary: boundary)
+        putHeaders(into: &request, from: apiRequest)
+
+        request.httpMethod = apiRequest.method.rawValue
+        return request
+    }
+}
+
+// MARK: - Private processing
+
+private extension UploadRequestBuilder {
+
+    /// Adds content of `additionalHeaders` from `APIRequest` instance into `URLRequest`.
+    func putHeaders<T: APIRequest>(into request: inout URLRequest, from apiRequest: T) {
+
+        if apiRequest.requiresAuth {
+            let strategy = authorizationProvider.makeStrategy(apiRequest.authorization)
+            if let authorization = strategy.value {
+                request.addValue(authorization, forHTTPHeaderField: "Authorization")
+            }
+        }
+
+        if let additionalHeaders = apiRequest.additionalHeaders {
+            for (headerField, value) in additionalHeaders {
+                request.addValue(value, forHTTPHeaderField: headerField)
+            }
+        }
+    }
+
+    private func createHttpBody(binaryData: Data, mimeType: String, filename: String, boundary: String) -> Data {
+        var postContent = "--\(boundary)\r\n"
+        postContent += "Content-Disposition: form-data; name=\"\(filename)\"; filename=\"\(filename)\"\r\n"
+        postContent += "Content-Type: \(mimeType)\r\n\r\n"
+
+        var data = Data()
+        guard let postData = postContent.data(using: .utf8) else { return data }
+        data.append(postData)
+        data.append(binaryData)
+
+        guard let endData = "\r\n--\(boundary)--\r\n".data(using: .utf8) else { return data }
+        data.append(endData)
+        return data
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/RequestBuilder/Encoding/Encoders/JSONParametersEncoder.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/RequestBuilder/Encoding/Encoders/JSONParametersEncoder.swift
@@ -1,0 +1,27 @@
+//
+//  JSONParametersEncoder.swift
+//  APIClient
+//
+//  Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Encodes `APIRequest` parameters as JSON into `URLRequest.httpBody` property.
+final class JSONParametersEncoder: ParametersEncoder {
+
+    func encode<T>(_ apiRequest: T, baseURL: URL) throws -> URLRequest where T: APIRequest {
+
+        var request = URLRequest(url: baseURL)
+
+        let encoder = JSONEncoder()
+        do {
+            let jsonData = try encoder.encode(apiRequest)
+            request.httpBody = jsonData
+        } catch {
+            throw NetworkingError.encoding
+        }
+
+        return request
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/RequestBuilder/Encoding/Encoders/RFC288ParametersEncoder.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/RequestBuilder/Encoding/Encoders/RFC288ParametersEncoder.swift
@@ -1,0 +1,23 @@
+//
+// RFC288ParametersEncoder.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+final class RFC288ParametersEncoder: ParametersEncoder {
+
+    func encode<T>(_ apiRequest: T, baseURL: URL) throws -> URLRequest where T: APIRequest {
+        var request = URLRequest(url: baseURL)
+
+        guard let messageValue = apiRequest.rfc288Value else {
+            fatalError("Request \(apiRequest) should never got here!")
+        }
+
+        request.httpBody = messageValue.data(using: .utf8)
+        return request
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/RequestBuilder/Encoding/Encoders/URLParametersEncoder.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/RequestBuilder/Encoding/Encoders/URLParametersEncoder.swift
@@ -1,0 +1,60 @@
+//
+//  URLParametersEncoder.swift
+//  APIClient
+//
+//  Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+enum URLParametersEncoderError: Error {
+    case baseURLParsingFailed
+    case urlAssemblingFailed
+}
+
+/// Encodes `APIRequest` parameters as URL query items into `URLRequest.url` property.
+final class URLParametersEncoder: ParametersEncoder {
+
+    func encode<T>(_ apiRequest: T, baseURL: URL) throws -> URLRequest where T: APIRequest {
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: true) else { throw URLParametersEncoderError.baseURLParsingFailed }
+        let customQueryItems: [URLQueryItem]
+        do {
+            customQueryItems = try URLParametersEncoder.encode(apiRequest)
+        } catch {
+            fatalError("Wrong parameters: \(error)")
+        }
+        if customQueryItems.isEmpty == false {
+            components.queryItems = customQueryItems
+            components.percentEncodedQuery = components.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")
+        }
+
+        guard let url = components.url else { throw URLParametersEncoderError.urlAssemblingFailed }
+        return URLRequest(url: url)
+    }
+}
+
+// MARK: - Private processing
+
+private extension URLParametersEncoder {
+
+    static func encode<T: APIRequest>(_ request: T) throws -> [URLQueryItem] {
+        let parametersData = try JSONEncoder().encode(request)
+        let parameters = try JSONDecoder().decode([String: HTTPParameter].self, from: parametersData)
+        return parameters.flatMap { queryComponents(fromKey: $0, value: $1) }.map { URLQueryItem(name: $0, value: $1) }
+    }
+
+    static func queryComponents(fromKey key: String, value: HTTPParameter) -> [(String, String?)] {
+        switch value {
+        case .string(let value):
+            return [(key, value)]
+        case .bool(let value):
+            return [(key, String(value))]
+        case .double(let value):
+            return [(key, String(value))]
+        case .int(let value):
+            return [(key, String(value))]
+        case let .array(array):
+            return array.map { ("\(key)[]", $0) }
+        }
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/RequestBuilder/Encoding/ParametersEncoder.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/RequestBuilder/Encoding/ParametersEncoder.swift
@@ -1,0 +1,20 @@
+//
+//  ParametersEncoder.swift
+//  APIClient
+//
+//  Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Encodes parameters of `APIRequest` implementation instance
+/// into `URLRequest` parameters.
+protocol ParametersEncoder {
+
+    /// Encodes parameter of `APIRequest` into `URLRequest` based on `HTTP` method.
+    /// - Parameters:
+    ///    - apiRequest: implementation instance of `APIRequest` protocol
+    ///    - baseURL: base `URL` of your server to create requests for.
+    /// - Returns: instance of `URLRequest` with encoded into it parameters.
+    func encode<T: APIRequest>(_ apiRequest: T, baseURL: URL) throws -> URLRequest
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/RequestBuilder/Encoding/ParametersEncodingFactory.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/RequestBuilder/Encoding/ParametersEncodingFactory.swift
@@ -1,0 +1,28 @@
+//
+//  ParametersEncodingFactory.swift
+//  APIClient
+//
+//  Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Desides and creates instance of `ParameterEncoder` protocol implementation based on `HTTPMethod`.
+enum ParametersEncodingFactory {
+
+    static func makeEncoder<T>(for apiRequest: T) -> ParametersEncoder where T: APIRequest {
+
+        let method = apiRequest.method.rawValue
+
+        if method == "GET" || method == "DELETE" {
+            return URLParametersEncoder()
+        } else if method == "POST" || method == "PUT" {
+            guard apiRequest.contentType == .applicationJson else {
+                return RFC288ParametersEncoder()
+            }
+            return JSONParametersEncoder()
+        } else {
+            fatalError("Not supported type: \(method)")
+        }
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/ResponseDecoder/JSONResponseDecoder.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/ResponseDecoder/JSONResponseDecoder.swift
@@ -1,0 +1,22 @@
+//
+// JSONResponseDecoder.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+struct JSONResponseDecoder: ResponseDecoder {
+
+    let decoder: JSONDecoder
+
+    init(decoder: JSONDecoder = JSONDecoder()) {
+        self.decoder = decoder
+    }
+
+    func decode<T>(_ type: T.Type, from data: Data) throws -> T where T: Decodable {
+        return try decoder.decode(type, from: data)
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/ResponseDecoder/RFC822ResponseDecoder.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/ResponseDecoder/RFC822ResponseDecoder.swift
@@ -1,0 +1,20 @@
+//
+// RFC822ResponseDecoder.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+struct RFC822ResponseDecoder: ResponseDecoder {
+
+    func decode<T>(_ type: T.Type, from data: Data) throws -> T where T: Decodable {
+        guard let responseString = String(data: data, encoding: .utf8) as? T else {
+            fatalError("Response should be string!")
+        }
+        return responseString
+    }
+
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/ResponseDecoder/ResponseDecoder.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/ResponseDecoder/ResponseDecoder.swift
@@ -1,0 +1,15 @@
+//
+// ResponseDecoder.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Prorocol describing process of decoding objects from `Data`.
+protocol ResponseDecoder {
+
+    func decode<T>(_ type: T.Type, from data: Data) throws -> T where T: Decodable
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/ResponseDecoder/ResponseDecoderFactory.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/ResponseDecoder/ResponseDecoderFactory.swift
@@ -1,0 +1,25 @@
+//
+// ResponseDecoderFactory.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+enum ResponseDecoderFactory {
+
+    static func makeDecoder(for headers: [AnyHashable: Any]) -> ResponseDecoder {
+        guard let contentType = headers["Content-Type"] as? String else {
+            return JSONResponseDecoder()
+        }
+
+        if contentType == "message/rfc822" {
+            return RFC822ResponseDecoder()
+        } else {
+            return JSONResponseDecoder()
+        }
+    }
+
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/URLSession/Configuration/URLSessionConfigurationBuilder.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/URLSession/Configuration/URLSessionConfigurationBuilder.swift
@@ -1,0 +1,79 @@
+//
+// URLSessionConfigurationBuilder.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Custom `URLSessionConfiguration` builder deisgned to add headers and
+/// custom implementations of `URLProtocol`.
+public class URLSessionConfigurationBuilder {
+
+    /// `URLSessionConfiguration` to be updated.
+    private let config: URLSessionConfiguration
+
+    public init(configuration: URLSessionConfiguration = URLSessionConfiguration.default) {
+        self.config = configuration
+    }
+
+    /// Adds single key-value header to configurations' `httpAdditionalHeaders` property.
+    /// - Parameters:
+    ///   - key: Headers's key to be stored.
+    ///   - value: Header's value to be stored.
+    /// - Returns: Instance of builder in order to continue building process.
+    public func additionalHeader(_ key: AnyHashable, value: Any) -> URLSessionConfigurationBuilder {
+        guard config.httpAdditionalHeaders != nil else {
+            config.httpAdditionalHeaders = [key: value]
+            return self
+        }
+        config.httpAdditionalHeaders?[key] = value
+        return self
+    }
+
+    /// Addes multiple key-value headers to configurations' `httpAdditionalHeaders` property.
+    /// - Parameter headers: Dictionary of key-value headers to be stored.
+    /// - Returns: Instance of builder in order to continue building process.
+    public func additionalHeaders(_ headers: [AnyHashable: Any]) -> URLSessionConfigurationBuilder {
+        guard config.httpAdditionalHeaders != nil else {
+            config.httpAdditionalHeaders = headers
+            return self
+        }
+        headers.forEach {
+            config.httpAdditionalHeaders?[$0.key] = $0.value
+        }
+        return self
+    }
+
+    /// Adds single `URLProtocol` class to configuration's `protocolClasses` property.
+    /// - Parameter protocolClass: `URLProtocol` implementation type to be stored.
+    /// - Returns: Instance of builder in order to continue building process.
+    public func requestProtocol(_ protocolClass: AnyClass) -> URLSessionConfigurationBuilder {
+        guard config.protocolClasses?.isEmpty == false else {
+            config.protocolClasses = [protocolClass]
+            return self
+        }
+        config.protocolClasses?.insert(protocolClass, at: 0)
+        return self
+    }
+
+    /// Adds multiple `URLProtocol` classes to configuration's `protocolClasses` property.
+    /// - Parameter protocolClasses: `URLProtocol` implementation types array to be stored.
+    /// - Returns: Instance of builder in order to continue building process.
+    public func requestProtocols(_ protocolClasses: [AnyClass]) -> URLSessionConfigurationBuilder {
+        guard let classes = config.protocolClasses else {
+            config.protocolClasses = protocolClasses
+            return self
+        }
+        config.protocolClasses = protocolClasses + classes
+        return self
+    }
+
+    /// Builds an instance of `URLSessionConfiguration`.
+    /// - Returns: Configured with previously stored headers and protocol classes configuration.
+    public func build() -> URLSessionConfiguration {
+        config
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/URLSession/Headers/DefaultSDKHeadersProvider.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/URLSession/Headers/DefaultSDKHeadersProvider.swift
@@ -1,0 +1,25 @@
+//
+// DefaultSDKHeadersProvider.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+import UIKit
+
+/// Defines default set of SDK headers with common data.
+public enum DefaultSDKHeadersProvider {
+
+    /// Static headers storage tied up to the application lifecycle.
+    public static var headers: [AnyHashable: Any] {
+        [
+            SDKHeaderKey.sdkName.rawValue: "iOS",
+            SDKHeaderKey.sdkVersion.rawValue: "1.0.0",
+            SDKHeaderKey.systemVersion.rawValue: UIDevice.current.systemVersion,
+            SDKHeaderKey.deviceIdiom.rawValue: UIDevice.current.model,
+            SDKHeaderKey.apiVersion.rawValue: "2.7"
+        ]
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/AnyCodable/AnyCodable.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/AnyCodable/AnyCodable.swift
@@ -1,0 +1,135 @@
+//
+// AnyCodable.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+@frozen public struct AnyCodable: Codable {
+    public let value: Any
+
+    public init<T>(_ value: T?) {
+        self.value = value ?? ()
+    }
+}
+
+extension AnyCodable: _AnyEncodable, _AnyDecodable {}
+
+extension AnyCodable: Equatable {
+    // swiftlint:disable:next cyclomatic_complexity
+    public static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {
+        switch (lhs.value, rhs.value) {
+        case is (Void, Void):
+            return true
+        case let (lhs as Bool, rhs as Bool):
+            return lhs == rhs
+        case let (lhs as Int, rhs as Int):
+            return lhs == rhs
+        case let (lhs as Int8, rhs as Int8):
+            return lhs == rhs
+        case let (lhs as Int16, rhs as Int16):
+            return lhs == rhs
+        case let (lhs as Int32, rhs as Int32):
+            return lhs == rhs
+        case let (lhs as Int64, rhs as Int64):
+            return lhs == rhs
+        case let (lhs as UInt, rhs as UInt):
+            return lhs == rhs
+        case let (lhs as UInt8, rhs as UInt8):
+            return lhs == rhs
+        case let (lhs as UInt16, rhs as UInt16):
+            return lhs == rhs
+        case let (lhs as UInt32, rhs as UInt32):
+            return lhs == rhs
+        case let (lhs as UInt64, rhs as UInt64):
+            return lhs == rhs
+        case let (lhs as Float, rhs as Float):
+            return lhs == rhs
+        case let (lhs as Double, rhs as Double):
+            return lhs == rhs
+        case let (lhs as String, rhs as String):
+            return lhs == rhs
+        case let (lhs as [String: AnyCodable], rhs as [String: AnyCodable]):
+            return lhs == rhs
+        case let (lhs as [AnyCodable], rhs as [AnyCodable]):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+}
+
+extension AnyCodable: CustomStringConvertible {
+    public var description: String {
+        switch value {
+        case is Void:
+            return String(describing: nil as Any?)
+        case let value as CustomStringConvertible:
+            return value.description
+        default:
+            return String(describing: value)
+        }
+    }
+}
+
+extension AnyCodable: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch value {
+        case let value as CustomDebugStringConvertible:
+            return "AnyCodable(\(value.debugDescription))"
+        default:
+            return "AnyCodable(\(description))"
+        }
+    }
+}
+
+extension AnyCodable: ExpressibleByNilLiteral {}
+extension AnyCodable: ExpressibleByBooleanLiteral {}
+extension AnyCodable: ExpressibleByIntegerLiteral {}
+extension AnyCodable: ExpressibleByFloatLiteral {}
+extension AnyCodable: ExpressibleByStringLiteral {}
+extension AnyCodable: ExpressibleByArrayLiteral {}
+extension AnyCodable: ExpressibleByDictionaryLiteral {}
+
+extension AnyCodable: Hashable {
+    // swiftlint:disable:next cyclomatic_complexity
+    public func hash(into hasher: inout Hasher) {
+        switch value {
+        case let value as Bool:
+            hasher.combine(value)
+        case let value as Int:
+            hasher.combine(value)
+        case let value as Int8:
+            hasher.combine(value)
+        case let value as Int16:
+            hasher.combine(value)
+        case let value as Int32:
+            hasher.combine(value)
+        case let value as Int64:
+            hasher.combine(value)
+        case let value as UInt:
+            hasher.combine(value)
+        case let value as UInt8:
+            hasher.combine(value)
+        case let value as UInt16:
+            hasher.combine(value)
+        case let value as UInt32:
+            hasher.combine(value)
+        case let value as UInt64:
+            hasher.combine(value)
+        case let value as Float:
+            hasher.combine(value)
+        case let value as Double:
+            hasher.combine(value)
+        case let value as String:
+            hasher.combine(value)
+        case let value as [String: AnyCodable]:
+            hasher.combine(value)
+        case let value as [AnyCodable]:
+            hasher.combine(value)
+        default:
+            break
+        }
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/AnyCodable/AnyDecodable.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/AnyCodable/AnyDecodable.swift
@@ -1,0 +1,170 @@
+//
+// AnyDecodable.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+@frozen public struct AnyDecodable: Decodable {
+    public let value: Any
+
+    public init<T>(_ value: T?) {
+        self.value = value ?? ()
+    }
+}
+
+// swiftlint:disable type_name
+@usableFromInline
+protocol _AnyDecodable {
+    var value: Any { get }
+    init<T>(_ value: T?)
+}
+
+extension AnyDecodable: _AnyDecodable {}
+
+extension _AnyDecodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            #if canImport(Foundation)
+                self.init(NSNull())
+            #else
+                self.init(Optional<Self>.none)
+            #endif
+        } else if let bool = try? container.decode(Bool.self) {
+            self.init(bool)
+        } else if let int = try? container.decode(Int.self) {
+            self.init(int)
+        } else if let uint = try? container.decode(UInt.self) {
+            self.init(uint)
+        } else if let double = try? container.decode(Double.self) {
+            self.init(double)
+        } else if let string = try? container.decode(String.self) {
+            self.init(string)
+        } else if let array = try? container.decode([AnyDecodable].self) {
+            self.init(array.map { $0.value })
+        } else if let dictionary = try? container.decode([String: AnyDecodable].self) {
+            self.init(dictionary.mapValues { $0.value })
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "AnyDecodable value cannot be decoded")
+        }
+    }
+}
+
+extension AnyDecodable: Equatable {
+    // swiftlint:disable:next cyclomatic_complexity
+    public static func == (lhs: AnyDecodable, rhs: AnyDecodable) -> Bool {
+        switch (lhs.value, rhs.value) {
+#if canImport(Foundation)
+        case is (NSNull, NSNull), is (Void, Void):
+            return true
+#endif
+        case let (lhs as Bool, rhs as Bool):
+            return lhs == rhs
+        case let (lhs as Int, rhs as Int):
+            return lhs == rhs
+        case let (lhs as Int8, rhs as Int8):
+            return lhs == rhs
+        case let (lhs as Int16, rhs as Int16):
+            return lhs == rhs
+        case let (lhs as Int32, rhs as Int32):
+            return lhs == rhs
+        case let (lhs as Int64, rhs as Int64):
+            return lhs == rhs
+        case let (lhs as UInt, rhs as UInt):
+            return lhs == rhs
+        case let (lhs as UInt8, rhs as UInt8):
+            return lhs == rhs
+        case let (lhs as UInt16, rhs as UInt16):
+            return lhs == rhs
+        case let (lhs as UInt32, rhs as UInt32):
+            return lhs == rhs
+        case let (lhs as UInt64, rhs as UInt64):
+            return lhs == rhs
+        case let (lhs as Float, rhs as Float):
+            return lhs == rhs
+        case let (lhs as Double, rhs as Double):
+            return lhs == rhs
+        case let (lhs as String, rhs as String):
+            return lhs == rhs
+        case let (lhs as [String: AnyDecodable], rhs as [String: AnyDecodable]):
+            return lhs == rhs
+        case let (lhs as [AnyDecodable], rhs as [AnyDecodable]):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+}
+
+extension AnyDecodable: CustomStringConvertible {
+    public var description: String {
+        switch value {
+        case is Void:
+            return String(describing: nil as Any?)
+        case let value as CustomStringConvertible:
+            return value.description
+        default:
+            return String(describing: value)
+        }
+    }
+}
+
+extension AnyDecodable: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch value {
+        case let value as CustomDebugStringConvertible:
+            return "AnyDecodable(\(value.debugDescription))"
+        default:
+            return "AnyDecodable(\(description))"
+        }
+    }
+}
+
+extension AnyDecodable: Hashable {
+    // swiftlint:disable:next cyclomatic_complexity
+    public func hash(into hasher: inout Hasher) {
+        switch value {
+        case let value as Bool:
+            hasher.combine(value)
+        case let value as Int:
+            hasher.combine(value)
+        case let value as Int8:
+            hasher.combine(value)
+        case let value as Int16:
+            hasher.combine(value)
+        case let value as Int32:
+            hasher.combine(value)
+        case let value as Int64:
+            hasher.combine(value)
+        case let value as UInt:
+            hasher.combine(value)
+        case let value as UInt8:
+            hasher.combine(value)
+        case let value as UInt16:
+            hasher.combine(value)
+        case let value as UInt32:
+            hasher.combine(value)
+        case let value as UInt64:
+            hasher.combine(value)
+        case let value as Float:
+            hasher.combine(value)
+        case let value as Double:
+            hasher.combine(value)
+        case let value as String:
+            hasher.combine(value)
+        case let value as [String: AnyDecodable]:
+            hasher.combine(value)
+        case let value as [AnyDecodable]:
+            hasher.combine(value)
+        default:
+            break
+        }
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/AnyCodable/AnyEncodable.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/AnyCodable/AnyEncodable.swift
@@ -1,0 +1,276 @@
+//
+// AnyEncodable.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+@frozen public struct AnyEncodable: Encodable {
+    public let value: Any
+
+    public init<T>(_ value: T?) {
+        self.value = value ?? ()
+    }
+}
+
+// swiftlint:disable type_name
+@usableFromInline
+protocol _AnyEncodable {
+    var value: Any { get }
+    init<T>(_ value: T?)
+}
+
+extension AnyEncodable: _AnyEncodable {}
+
+// MARK: - Encodable
+extension _AnyEncodable {
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch value {
+        #if canImport(Foundation)
+        case is NSNull:
+            try container.encodeNil()
+        #endif
+        case is Void:
+            try container.encodeNil()
+        case let bool as Bool:
+            try container.encode(bool)
+        case let int as Int:
+            try container.encode(int)
+        case let int8 as Int8:
+            try container.encode(int8)
+        case let int16 as Int16:
+            try container.encode(int16)
+        case let int32 as Int32:
+            try container.encode(int32)
+        case let int64 as Int64:
+            try container.encode(int64)
+        case let uint as UInt:
+            try container.encode(uint)
+        case let uint8 as UInt8:
+            try container.encode(uint8)
+        case let uint16 as UInt16:
+            try container.encode(uint16)
+        case let uint32 as UInt32:
+            try container.encode(uint32)
+        case let uint64 as UInt64:
+            try container.encode(uint64)
+        case let float as Float:
+            try container.encode(float)
+        case let double as Double:
+            try container.encode(double)
+        case let string as String:
+            try container.encode(string)
+        #if canImport(Foundation)
+        case let number as NSNumber:
+            try encode(nsnumber: number, into: &container)
+        case let date as Date:
+            try container.encode(date)
+        case let url as URL:
+            try container.encode(url)
+        #endif
+        case let array as [Any?]:
+            try container.encode(array.map { AnyEncodable($0) })
+        case let dictionary as [String: Any?]:
+            try container.encode(dictionary.mapValues { AnyEncodable($0) })
+        case let encodable as Encodable:
+            try encodable.encode(to: encoder)
+        default:
+            let context = EncodingError.Context(codingPath: container.codingPath, debugDescription: "AnyEncodable value cannot be encoded")
+            throw EncodingError.invalidValue(value, context)
+        }
+    }
+
+    #if canImport(Foundation)
+    // swiftlint:disable:next cyclomatic_complexity
+    private func encode(nsnumber: NSNumber, into container: inout SingleValueEncodingContainer) throws {
+        switch Character(Unicode.Scalar(UInt8(nsnumber.objCType.pointee))) {
+        case "B":
+            try container.encode(nsnumber.boolValue)
+        case "c":
+            try container.encode(nsnumber.int8Value)
+        case "s":
+            try container.encode(nsnumber.int16Value)
+        case "i", "l":
+            try container.encode(nsnumber.int32Value)
+        case "q":
+            try container.encode(nsnumber.int64Value)
+        case "C":
+            try container.encode(nsnumber.uint8Value)
+        case "S":
+            try container.encode(nsnumber.uint16Value)
+        case "I", "L":
+            try container.encode(nsnumber.uint32Value)
+        case "Q":
+            try container.encode(nsnumber.uint64Value)
+        case "f":
+            try container.encode(nsnumber.floatValue)
+        case "d":
+            try container.encode(nsnumber.doubleValue)
+        default:
+            let context = EncodingError.Context(codingPath: container.codingPath, debugDescription: "NSNumber cannot be encoded because its type is not handled")
+            throw EncodingError.invalidValue(nsnumber, context)
+        }
+    }
+    #endif
+}
+
+extension AnyEncodable: Equatable {
+    // swiftlint:disable:next cyclomatic_complexity
+    public static func == (lhs: AnyEncodable, rhs: AnyEncodable) -> Bool {
+        switch (lhs.value, rhs.value) {
+        case is (Void, Void):
+            return true
+        case let (lhs as Bool, rhs as Bool):
+            return lhs == rhs
+        case let (lhs as Int, rhs as Int):
+            return lhs == rhs
+        case let (lhs as Int8, rhs as Int8):
+            return lhs == rhs
+        case let (lhs as Int16, rhs as Int16):
+            return lhs == rhs
+        case let (lhs as Int32, rhs as Int32):
+            return lhs == rhs
+        case let (lhs as Int64, rhs as Int64):
+            return lhs == rhs
+        case let (lhs as UInt, rhs as UInt):
+            return lhs == rhs
+        case let (lhs as UInt8, rhs as UInt8):
+            return lhs == rhs
+        case let (lhs as UInt16, rhs as UInt16):
+            return lhs == rhs
+        case let (lhs as UInt32, rhs as UInt32):
+            return lhs == rhs
+        case let (lhs as UInt64, rhs as UInt64):
+            return lhs == rhs
+        case let (lhs as Float, rhs as Float):
+            return lhs == rhs
+        case let (lhs as Double, rhs as Double):
+            return lhs == rhs
+        case let (lhs as String, rhs as String):
+            return lhs == rhs
+        case let (lhs as [String: AnyEncodable], rhs as [String: AnyEncodable]):
+            return lhs == rhs
+        case let (lhs as [AnyEncodable], rhs as [AnyEncodable]):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+}
+
+extension AnyEncodable: CustomStringConvertible {
+    public var description: String {
+        switch value {
+        case is Void:
+            return String(describing: nil as Any?)
+        case let value as CustomStringConvertible:
+            return value.description
+        default:
+            return String(describing: value)
+        }
+    }
+}
+
+extension AnyEncodable: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch value {
+        case let value as CustomDebugStringConvertible:
+            return "AnyEncodable(\(value.debugDescription))"
+        default:
+            return "AnyEncodable(\(description))"
+        }
+    }
+}
+
+extension AnyEncodable: ExpressibleByNilLiteral {}
+extension AnyEncodable: ExpressibleByBooleanLiteral {}
+extension AnyEncodable: ExpressibleByIntegerLiteral {}
+extension AnyEncodable: ExpressibleByFloatLiteral {}
+extension AnyEncodable: ExpressibleByStringLiteral {}
+extension AnyEncodable: ExpressibleByStringInterpolation {}
+extension AnyEncodable: ExpressibleByArrayLiteral {}
+extension AnyEncodable: ExpressibleByDictionaryLiteral {}
+
+extension _AnyEncodable {
+    public init(nilLiteral _: ()) {
+        self.init(nil as Any?)
+    }
+
+    public init(booleanLiteral value: Bool) {
+        self.init(value)
+    }
+
+    public init(integerLiteral value: Int) {
+        self.init(value)
+    }
+
+    public init(floatLiteral value: Double) {
+        self.init(value)
+    }
+
+    public init(extendedGraphemeClusterLiteral value: String) {
+        self.init(value)
+    }
+
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+
+    public init(arrayLiteral elements: Any...) {
+        self.init(elements)
+    }
+
+    public init(dictionaryLiteral elements: (AnyHashable, Any)...) {
+        self.init([AnyHashable: Any](elements, uniquingKeysWith: { first, _ in first }))
+    }
+}
+
+extension AnyEncodable: Hashable {
+    // swiftlint:disable:next cyclomatic_complexity
+    public func hash(into hasher: inout Hasher) {
+        switch value {
+        case let value as Bool:
+            hasher.combine(value)
+        case let value as Int:
+            hasher.combine(value)
+        case let value as Int8:
+            hasher.combine(value)
+        case let value as Int16:
+            hasher.combine(value)
+        case let value as Int32:
+            hasher.combine(value)
+        case let value as Int64:
+            hasher.combine(value)
+        case let value as UInt:
+            hasher.combine(value)
+        case let value as UInt8:
+            hasher.combine(value)
+        case let value as UInt16:
+            hasher.combine(value)
+        case let value as UInt32:
+            hasher.combine(value)
+        case let value as UInt64:
+            hasher.combine(value)
+        case let value as Float:
+            hasher.combine(value)
+        case let value as Double:
+            hasher.combine(value)
+        case let value as String:
+            hasher.combine(value)
+        case let value as [String: AnyEncodable]:
+            hasher.combine(value)
+        case let value as [AnyEncodable]:
+            hasher.combine(value)
+        default:
+            break
+        }
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Builder/AuthURLBuilder.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Builder/AuthURLBuilder.swift
@@ -1,0 +1,31 @@
+//
+// AuthURLBuilder.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+public enum AuthURLBuilder {
+
+    public static func build(with query: [QueryItem]) throws -> URL {
+
+        guard !query.isEmpty else {
+            throw URLBuilderError.emptyParams
+        }
+
+        guard var components = URLComponents(url: Environment.authURL, resolvingAgainstBaseURL: false) else {
+            throw URLBuilderError.invalidBaseURL
+        }
+
+        components.queryItems = query.map { URLQueryItem(name: $0.name, value: $0.value) }
+
+        guard let url = components.url else {
+            throw URLBuilderError.invalidResult
+        }
+
+        return url
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Environment/Environment.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Environment/Environment.swift
@@ -1,0 +1,28 @@
+//
+// Environment.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+// swiftlint:disable all
+// swift-format-ignore-file
+// swiftformat:disable all
+
+import Foundation
+
+public enum Environment {
+//
+//    #if DEBUG
+    public static let baseURL: URL = URL(string: "https://neural-parsers-staging.us.nylas.com")!
+//    #else
+//    public static let baseURL: URL = URL(string: "https://neural-parsers.us.nylas.com")!
+//    #endif
+
+    public static let amazonBaseURL: URL = URL(string: "https://www.amazon.com")!
+
+    public static let authURL: URL = {
+        return baseURL.appendingPathComponent("oauth/authorize")
+    }()
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Extension/Public/PropertyWrapper/File.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Extension/Public/PropertyWrapper/File.swift
@@ -1,0 +1,23 @@
+//
+//  FailableDecodable.swift
+//  
+//
+//  Created by Ostap Holub on 06.03.2023.
+//
+
+import Foundation
+
+@propertyWrapper
+public struct FailableDecodable<Wrapped: Codable>: Codable {
+    public var wrappedValue: Wrapped?
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        wrappedValue = try? container.decode(Wrapped.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(wrappedValue)
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Extension/Public/URL+Auth.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Extension/Public/URL+Auth.swift
@@ -1,0 +1,46 @@
+//
+// URL+Auth.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+extension URL {
+
+    var urlComponents: URLComponents? {
+        return URLComponents(url: self, resolvingAgainstBaseURL: false)
+    }
+}
+
+public extension URL {
+
+    var error: AuthError? {
+        guard let errorKey = urlComponents?.queryItems?.first(where: { $0.name == "error" })?.value,
+              let errorDescription = urlComponents?.queryItems?.first(where: { $0.name == "error_description" })?.value else {
+            return nil
+        }
+
+        return AuthError.makeError(key: errorKey, message: errorDescription)
+    }
+
+    var accountId: String? {
+        return urlComponents?
+            .queryItems?.first(where: { $0.name == "account_id" })?
+            .nonEmptyValue
+    }
+
+    var accessToken: String? {
+        return urlComponents?.queryItems?.first(where: { $0.name == "access_token" })?.nonEmptyValue
+    }
+
+    var provider: String? {
+        return urlComponents?.queryItems?.first(where: { $0.name == "provider" })?.nonEmptyValue
+    }
+
+    var email: String? {
+        return urlComponents?.queryItems?.first(where: { $0.name == "email_address" })?.nonEmptyValue
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Extension/Public/URL+MimeType.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Extension/Public/URL+MimeType.swift
@@ -1,0 +1,21 @@
+//
+// URL+MimeType.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+import UniformTypeIdentifiers
+
+public extension URL {
+
+    var mimeType: String {
+        if let mimeType = UTType(filenameExtension: self.pathExtension)?.preferredMIMEType {
+            return mimeType
+        } else {
+            return "application/octet-stream"
+        }
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Extension/Public/URL+Trim.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Extension/Public/URL+Trim.swift
@@ -1,0 +1,21 @@
+//
+// URL+Trim.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+public extension URL {
+
+    var removingQueries: URL {
+        if var components = URLComponents(string: absoluteString) {
+            components.query = nil
+            return components.url ?? self
+        } else {
+            return self
+        }
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Extension/Public/URLQueryItem+Fallback.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Extension/Public/URLQueryItem+Fallback.swift
@@ -1,0 +1,16 @@
+//
+// URLQueryItem+Fallback.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+public extension URLQueryItem {
+
+    var nonEmptyValue: String? {
+        return value == "" ? nil : value
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Error/AuthError.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Error/AuthError.swift
@@ -1,0 +1,51 @@
+//
+// AuthError.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+public enum AuthError: Error, Equatable {
+    case unknown(String)
+    case invalidRequest(String)
+    case accessDenied(String)
+    case unauthorizedClient(String)
+    case unsupportedResponseType(String)
+    case invalidScope(String)
+    case serverError(String)
+    case temporarilyUnavailable(String)
+}
+
+extension AuthError: LocalizedError {
+
+    public var errorDescription: String? {
+        switch self {
+        case let .unknown(message),
+            let .invalidRequest(message),
+            let .accessDenied(message),
+            let .unauthorizedClient(message),
+            let .unsupportedResponseType(message),
+            let .invalidScope(message),
+            let .serverError(message),
+            let .temporarilyUnavailable(message):
+            return message
+        }
+    }
+
+    public static func makeError(key: String, message: String) -> AuthError? {
+        switch key {
+        case "unknown": return .unknown(message)
+        case "invalid_request": return .invalidRequest(message)
+        case "access_denied": return .accessDenied(message)
+        case "unauthorized_client": return .unauthorizedClient(message)
+        case "unsupported_response_type": return .unsupportedResponseType(message)
+        case "invalid_scope": return .invalidScope(message)
+        case "server_error": return .serverError(message)
+        case "temporarily_unavailable": return .temporarilyUnavailable(message)
+        default: return nil
+        }
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Error/HTTPError.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Error/HTTPError.swift
@@ -1,0 +1,39 @@
+//
+// HTTPError.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Describes possible `HTTP` protocol errors that might appear during
+/// execution of Network code.
+public enum HTTPError: Error {
+    case badRequest(HTTPErrorPayload)
+    case unauthorised
+    case notFound(HTTPErrorPayload)
+    case internalServer(HTTPErrorPayload)
+    case tooManyRequests(HTTPErrorPayload)
+    case forbidden(HTTPErrorPayload)
+}
+
+// MARK: - LocalizedError
+
+/// Internal extension providing localized description for an error.
+extension HTTPError: LocalizedError {
+
+    public var errorDescription: String? {
+        switch self {
+        case let .badRequest(payload),
+            let .notFound(payload),
+            let .internalServer(payload),
+            let .tooManyRequests(payload),
+            let .forbidden(payload):
+            return payload.message
+        case .unauthorised:
+            return "Not authorized to perform the request."
+        }
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Error/HTTPErrorPayload.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Error/HTTPErrorPayload.swift
@@ -1,0 +1,35 @@
+//
+// HTTPErrorPayload.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Describes uniform response from server for not success status codes.
+public struct HTTPErrorPayload: Codable {
+
+    public let success: Bool
+
+    public let error: NeuralError
+
+    public var message: String {
+        error.message
+    }
+}
+
+public struct NeuralError: Codable {
+    let type: String
+    let message: String
+    let httpCode: Int
+    let eventCode: Int
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case message
+        case httpCode = "http_code"
+        case eventCode = "event_code"
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Error/NetworkingError.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Error/NetworkingError.swift
@@ -1,0 +1,36 @@
+//
+//  NetworkingError.swift
+//  Core
+//
+//  Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Describes possible networking code errors that happens before sending
+/// an `HTTP` request or response processing.
+public enum NetworkingError: Error {
+    case invalidResource
+    case encoding
+    case decoding(rawData: Data, error: Error)
+    case unknown
+    case responseProcessing
+    case invalidView
+}
+
+// MARK: - LocalizedError
+
+/// Internal extension providing localized description for an error.
+extension NetworkingError: LocalizedError {
+
+    public var errorDescription: String? {
+        switch self {
+        case let .decoding(_, error):
+            return error.localizedDescription
+        case .invalidView:
+            return "Requested and actual views mismatch"
+        default:
+            return String(describing: self)
+        }
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Error/URLBuilderError.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Error/URLBuilderError.swift
@@ -1,0 +1,15 @@
+//
+// URLBuilderError.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+public enum URLBuilderError: Error {
+    case invalidBaseURL
+    case invalidResult
+    case emptyParams
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Public/Authorization.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Public/Authorization.swift
@@ -1,0 +1,14 @@
+//
+//  Authorization.swift
+//  
+//
+//  Created by Ostap Holub on 23.02.2023.
+//
+
+import Foundation
+
+public enum Authorization {
+    case basic
+    case bearer
+    case none
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Public/FileUpload.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Public/FileUpload.swift
@@ -1,0 +1,18 @@
+//
+// FileUpload.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+public enum FileUpload {
+
+    public enum Key: String {
+        case boundary = "boundary"
+        case fileURL = "url"
+        case filename = "filename"
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Public/HTTPMethod.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Public/HTTPMethod.swift
@@ -1,0 +1,18 @@
+//
+//  HTTPMethod.swift
+//  
+//
+//  Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Describes HTTP methods with `String` raw value for `APIRequest` desctiption.
+public enum HTTPMethod: String, Encodable {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case delete = "DELETE"
+    case patch = "PATCH"
+    case head = "HEAD"
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Public/Metadata.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Public/Metadata.swift
@@ -1,0 +1,23 @@
+//
+//  Metadata.swift
+//  
+//
+//  Created by Ostap Holub on 23.02.2023.
+//
+
+import Foundation
+
+/// Convenience typealias for Dictionary type.
+public typealias Metadata = [String: AnyCodable]
+
+public extension Metadata {
+
+    var JSONString: String {
+        do {
+            let data = try JSONSerialization.data(withJSONObject: self)
+            return String(data: data, encoding: .utf8) ?? ""
+        } catch {
+            return ""
+        }
+    }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Public/QueryItem.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Model/Public/QueryItem.swift
@@ -1,0 +1,19 @@
+//
+// QueryItem.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Describes a generic query item for URL building purposes.
+public protocol QueryItem {
+
+    /// Name of the query parameter
+    var name: String { get }
+
+    /// Value of the query parameter
+    var value: String { get }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Protocols/APIClient.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Protocols/APIClient.swift
@@ -1,0 +1,28 @@
+//
+//  APIClient.swift
+//
+//
+//  Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Defines protocol for custom APIClient implementations.
+public protocol APIClient {
+
+    /// Sends request over the HTTP protocol.
+    /// - Parameter request: Instance of `APIRequest` protocol implementation
+    /// describing the request to be sent.
+    /// - Returns: Return instance of associated type of `APIRequest.Response`.
+    func send<T: APIRequest>(_ request: T) async throws -> T.Response
+
+    /// Downloads content of URL defined by request.
+    /// - Parameters:
+    ///   - request: Instance of `APIRequest` protocol implementation describing the request to be sent.
+    func download<T: APIRequest>(_ request: T) async throws -> URL
+
+    /// Uploads content of URL.
+    /// - Parameters:
+    ///   - request: Instance of `APIRequest` protocol implementation describing the request to be sent.
+    func upload<T: APIRequest>(_ request: T, fileURL: URL) async throws -> T.Response
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Protocols/APIRequest.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Protocols/APIRequest.swift
@@ -1,0 +1,48 @@
+//
+//  APIRequest.swift
+//  
+//
+//  Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+/// Describes protocol for HTTP APIRequest.
+public protocol APIRequest: Encodable {
+
+    /// Associated type that represents any `Decodable` object to be treated as
+    /// HTTP response data.
+    associatedtype Response: Decodable
+
+    /// Route to endpoint of resource.
+    var resourceName: String { get }
+
+    /// HTTP Method to be used to perform HTTP API Request.
+    var method: HTTPMethod { get }
+
+    /// Additional HTTP headers to be sent with request.
+    var additionalHeaders: [String: String]? { get }
+
+    /// Indicates which type of authorization is supported.
+    var authorization: Authorization { get }
+
+    /// Indicates wheter the request requires authentication header to be present
+    /// in order to be sent.
+    var requiresAuth: Bool { get }
+
+    /// Content type of request.
+    var contentType: RequestContentType { get }
+
+    /// Optional RFC288 value as workaround. Always nil.
+    var rfc288Value: String? { get }
+}
+
+/// Provides convenience configuration for any implementation of `APIRequest`
+public extension APIRequest {
+
+    var authorization: Authorization { .none }
+    var requiresAuth: Bool { true }
+    var additionalHeaders: [String: String]? { nil }
+    var contentType: RequestContentType { .applicationJson }
+    var rfc288Value: String? { nil }
+}

--- a/DropboxBrowser/APIClient/Sources/APIClient/Utils/Protocols/ContentType.swift
+++ b/DropboxBrowser/APIClient/Sources/APIClient/Utils/Protocols/ContentType.swift
@@ -1,0 +1,13 @@
+//
+// ContentType.swift
+// APIClient
+//
+
+// Created by Ostap Holub on 02.09.2023.
+//
+
+import Foundation
+
+public enum RequestContentType: String {
+    case applicationJson = "application/json"
+}

--- a/DropboxBrowser/APIClient/Tests/APIClientTests/APIClientTests.swift
+++ b/DropboxBrowser/APIClient/Tests/APIClientTests/APIClientTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import APIClient
+
+final class APIClientTests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+        XCTAssertEqual(APIClient().text, "Hello, World!")
+    }
+}

--- a/DropboxBrowser/DropboxBrowser.xcodeproj/project.pbxproj
+++ b/DropboxBrowser/DropboxBrowser.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		116EC83E2AA3941B0055C2B8 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 116EC8402AA3941B0055C2B8 /* Localizable.strings */; };
 		116EC8432AA396660055C2B8 /* Assets.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116EC8412AA396660055C2B8 /* Assets.generated.swift */; };
 		116EC8442AA396660055C2B8 /* Strings.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116EC8422AA396660055C2B8 /* Strings.generated.swift */; };
+		11C1B8952AA39A0400FC44CE /* APIClient in Frameworks */ = {isa = PBXBuildFile; productRef = 11C1B8942AA39A0400FC44CE /* APIClient */; };
 		11F150902AA37EFC00E6E5CA /* DropboxBrowserApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F1508F2AA37EFC00E6E5CA /* DropboxBrowserApp.swift */; };
 		11F150922AA37EFC00E6E5CA /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F150912AA37EFC00E6E5CA /* ContentView.swift */; };
 		11F150942AA37EFD00E6E5CA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 11F150932AA37EFD00E6E5CA /* Assets.xcassets */; };
@@ -64,6 +65,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				11C1B8952AA39A0400FC44CE /* APIClient in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -84,6 +86,13 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		11C1B8932AA39A0400FC44CE /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		11F150832AA37EFC00E6E5CA = {
 			isa = PBXGroup;
 			children = (
@@ -91,6 +100,7 @@
 				11F1509F2AA37EFD00E6E5CA /* DropboxBrowserTests */,
 				11F150A92AA37EFD00E6E5CA /* DropboxBrowserUITests */,
 				11F1508D2AA37EFC00E6E5CA /* Products */,
+				11C1B8932AA39A0400FC44CE /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -223,6 +233,9 @@
 			dependencies = (
 			);
 			name = DropboxBrowser;
+			packageProductDependencies = (
+				11C1B8942AA39A0400FC44CE /* APIClient */,
+			);
 			productName = DropboxBrowser;
 			productReference = 11F1508C2AA37EFC00E6E5CA /* DropboxBrowser.app */;
 			productType = "com.apple.product-type.application";
@@ -729,6 +742,13 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		11C1B8942AA39A0400FC44CE /* APIClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = APIClient;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 11F150842AA37EFC00E6E5CA /* Project object */;
 }

--- a/DropboxBrowser/DropboxBrowser.xcworkspace/contents.xcworkspacedata
+++ b/DropboxBrowser/DropboxBrowser.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:DropboxBrowser.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:APIClient">
+   </FileRef>
+</Workspace>

--- a/DropboxBrowser/DropboxBrowser.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/DropboxBrowser/DropboxBrowser.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
# Overview

Adds local SPM called `APIClient` that stores common use interfaces, classes, utils for making API requests.

# Code changes

- [x] Create local SPM package
- [x] Setup link between app and package
- [x] Move all the interfaces, classes, structs into package  

# Readiness checklist

- [ ] Included before/after screenshots, if the change is visual: none
- [ ] Included video of working feature, if the change is new feature: none

# Testing

*A summary of what testing was performed.*
Include APIClient into app target, build and run the app. 

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
